### PR TITLE
 refactor(#26): parser types now pass all test cases

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -63,7 +63,7 @@ impl Display for Type {
             },
             Self::Heap { is_pointer: false, contents } => {
                 write!(f, "{{")?;
-                for (t, elems) in contents {
+                for (i, (t, elems)) in contents.iter().enumerate() {
                     write!(f, "{t}")?;
                     match elems {
                         Some(0) => write!(f, ":")?,
@@ -71,7 +71,9 @@ impl Display for Type {
                         None => {},
                     };
 
-                    write!(f, ", ")?;
+                    if i != contents.len() -1 {
+                        write!(f, ", ")?;
+                    }
                 }
                 write!(f, "}}")?;
             },

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -50,19 +50,8 @@ impl Display for Type {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Size(s) => write!(f, "{s}")?,
-            Self::Heap { is_pointer: true, contents } => {
-                // contents length is always 1 for pointers
-                write!(f, "[{}", &contents[0].0)?;
-                match contents[0].1 {
-                    Some(0) => write!(f, ":")?,
-                    Some(size) => write!(f, ":{size}")?,
-                    None => {},
-                };
-
-                write!(f, "]")?;
-            },
-            Self::Heap { is_pointer: false, contents } => {
-                write!(f, "{{")?;
+            Self::Heap { is_pointer, contents } => {
+                write!(f, "{}", if *is_pointer {"["} else {"{"})?;
                 for (i, (t, elems)) in contents.iter().enumerate() {
                     write!(f, "{t}")?;
                     match elems {
@@ -75,7 +64,7 @@ impl Display for Type {
                         write!(f, ", ")?;
                     }
                 }
-                write!(f, "}}")?;
+                write!(f, "{}", if *is_pointer {"]"} else {"}"})?;
             },
             Self::Register { inner: t, ident } => {
                 if t.is_some() {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -51,7 +51,7 @@ impl Display for Type {
         match self {
             Self::Size(s) => write!(f, "{s}")?,
             Self::Heap { is_pointer, contents } => {
-                write!(f, "{}", if *is_pointer {"["} else {"{"})?;
+                write!(f, "{}", if *is_pointer { "[" } else { "{" })?;
                 for (i, (t, elems)) in contents.iter().enumerate() {
                     write!(f, "{t}")?;
                     match elems {
@@ -60,11 +60,11 @@ impl Display for Type {
                         None => {},
                     };
 
-                    if i != contents.len() -1 {
+                    if i != contents.len() - 1 {
                         write!(f, ", ")?;
                     }
                 }
-                write!(f, "{}", if *is_pointer {"]"} else {"}"})?;
+                write!(f, "{}", if *is_pointer { "]" } else { "}" })?;
             },
             Self::Register { inner: t, ident } => {
                 if t.is_some() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -379,7 +379,10 @@ impl<'t, 'contents> Parser<'t, 'contents> {
             TokenKind::Identifier => Ok(()),
             TokenKind::DecimalIntLiteral => ReportKind::SyntaxError
                 .new("Expected register starting with r")
-                .with_note(format!("HINT: You forgot the r prefix. Do: r{}", self.current.text))
+                .with_note(format!(
+                        "HINT: You forgot the r prefix. Do: r{}",
+                        self.current.text
+                ))
                 .with_label(ReportLabel::new(self.current.span.clone()))
                 .into(),
             _ => ReportKind::UnexpectedToken
@@ -389,7 +392,7 @@ impl<'t, 'contents> Parser<'t, 'contents> {
                 .into(),
         }?;
 
-        if !self.current.text.starts_with('r') {
+        if !self.current.text.starts_with("r") {
             return ReportKind::SyntaxError
                 .new("Register identifier format is incorrect!")
                 .with_label(ReportLabel::new(self.current.span.clone()))
@@ -397,12 +400,14 @@ impl<'t, 'contents> Parser<'t, 'contents> {
                 .into();
         }
 
-        match self.current.text.strip_prefix('r').unwrap().parse::<usize>() {
+        match self.current.text.strip_prefix("r").unwrap().parse::<usize>() {
             Err(e) => match e.kind() {
                 IntErrorKind::Empty => ReportKind::SyntaxError
                     .new("Expected register identifier after r prefix")
                     .with_label(ReportLabel::new(self.current.span.clone()))
-                    .with_note("HINT: Registers follow the format r<ident>. e.g r8 r32"),
+                    .with_note(
+                        "HINT: Registers follow the format r<ident>. e.g r8 r32",
+                    ),
                 IntErrorKind::InvalidDigit => {
                     let mut span = self.current.span.clone();
                     span.start_index += 1;
@@ -411,15 +416,16 @@ impl<'t, 'contents> Parser<'t, 'contents> {
                     ReportKind::SyntaxError
                         .new("Register number contains an invalid digit")
                         .with_label(ReportLabel::new(self.current.span.clone()))
-                        .with_note("HINT: Registers follow the format r<ident>. e.g r8 r32")
+                        .with_note(
+                            "HINT: Registers follow the format r<ident>. e.g r8 r32",
+                        )
                 },
                 _ => ReportKind::SyntaxError
                     .new("Register identifier intager overflows")
                     .with_label(ReportLabel::new(self.current.span.clone()))
                     .with_note("HINT: You dont have this many registers. Trust me"),
-            }
-            .into(),
-            Ok(i) => Ok(Type::Register { inner: inner.map(|t| Box::new(t)), ident: i }),
+            }.into(),
+            Ok(i) => Ok(Type::Register { inner: inner.map(|t| Box::new(t)), ident: i })
         }
     }
 
@@ -453,7 +459,7 @@ impl<'t, 'contents> Parser<'t, 'contents> {
                             if n == Some(0) {
                                 return ReportKind::SyntaxError
                                     .new("Array size cannot be zero.")
-                                    .with_note(format!("HINT: Did you mean [{t}:]"))
+                                    .with_note(format!("HINT: Did you mean [{}:]", t))
                                     .with_label(ReportLabel::new(self.current.span.clone()))
                                     .into();
                             }
@@ -472,8 +478,8 @@ impl<'t, 'contents> Parser<'t, 'contents> {
                 // We should fail earlier but we wait to gather the element size
                 // n before logging for clearer error logging
                 if let Type::Register { inner, ident } = t {
-                    let mut inner_str = String::new();
-                    let mut n_str = String::new();
+                    let mut inner_str = "".to_string();
+                    let mut n_str = "".to_string();
                     if inner.is_some() {
                         inner_str = format!("{}", inner.unwrap());
                     }
@@ -531,13 +537,14 @@ impl<'t, 'contents> Parser<'t, 'contents> {
                                 if n == Some(0) {
                                     return ReportKind::SyntaxError
                                         .new("Array size cannot be zero.")
-                                        .with_note(format!("HINT: Did you mean {t}:"))
+                                        .with_note(format!("HINT: Did you mean {}:", t))
                                         .with_label(ReportLabel::new(self.current.span.clone()))
                                         .into();
                                 }
                                 self.advance();
                             },
-                            TokenKind::Comma | TokenKind::RBrace => {},
+                            TokenKind::Comma => {},
+                            TokenKind::RBrace => {},
                             _ => {
                                 self.advance();
                                 return ReportKind::UnexpectedToken

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -389,7 +389,7 @@ impl<'t, 'contents> Parser<'t, 'contents> {
                 .into(),
         }?;
 
-        if !self.current.text.starts_with("r") {
+        if !self.current.text.starts_with('r') {
             return ReportKind::SyntaxError
                 .new("Register identifier format is incorrect!")
                 .with_label(ReportLabel::new(self.current.span.clone()))
@@ -453,7 +453,7 @@ impl<'t, 'contents> Parser<'t, 'contents> {
                             if n == Some(0) {
                                 return ReportKind::SyntaxError
                                     .new("Array size cannot be zero.")
-                                    .with_note(format!("HINT: Did you mean [{}:]", t))
+                                    .with_note(format!("HINT: Did you mean [{t}:]"))
                                     .with_label(ReportLabel::new(self.current.span.clone()))
                                     .into();
                             }
@@ -472,8 +472,8 @@ impl<'t, 'contents> Parser<'t, 'contents> {
                 // We should fail earlier but we wait to gather the element size
                 // n before logging for clearer error logging
                 if let Type::Register { inner, ident } = t {
-                    let mut inner_str = "".to_string();
-                    let mut n_str = "".to_string();
+                    let mut inner_str = String::new();
+                    let mut n_str = String::new();
                     if inner.is_some() {
                         inner_str = format!("{}", inner.unwrap());
                     }
@@ -531,14 +531,13 @@ impl<'t, 'contents> Parser<'t, 'contents> {
                                 if n == Some(0) {
                                     return ReportKind::SyntaxError
                                         .new("Array size cannot be zero.")
-                                        .with_note(format!("HINT: Did you mean {}:", t))
+                                        .with_note(format!("HINT: Did you mean {t}:"))
                                         .with_label(ReportLabel::new(self.current.span.clone()))
                                         .into();
                                 }
                                 self.advance();
                             },
-                            TokenKind::Comma => {},
-                            TokenKind::RBrace => {},
+                            TokenKind::Comma | TokenKind::RBrace => {},
                             _ => {
                                 self.advance();
                                 return ReportKind::UnexpectedToken

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -379,10 +379,7 @@ impl<'t, 'contents> Parser<'t, 'contents> {
             TokenKind::Identifier => Ok(()),
             TokenKind::DecimalIntLiteral => ReportKind::SyntaxError
                 .new("Expected register starting with r")
-                .with_note(format!(
-                        "HINT: You forgot the r prefix. Do: r{}",
-                        self.current.text
-                ))
+                .with_note(format!("HINT: You forgot the r prefix. Do: r{}", self.current.text))
                 .with_label(ReportLabel::new(self.current.span.clone()))
                 .into(),
             _ => ReportKind::UnexpectedToken
@@ -405,9 +402,7 @@ impl<'t, 'contents> Parser<'t, 'contents> {
                 IntErrorKind::Empty => ReportKind::SyntaxError
                     .new("Expected register identifier after r prefix")
                     .with_label(ReportLabel::new(self.current.span.clone()))
-                    .with_note(
-                        "HINT: Registers follow the format r<ident>. e.g r8 r32",
-                    ),
+                    .with_note("HINT: Registers follow the format r<ident>. e.g r8 r32"),
                 IntErrorKind::InvalidDigit => {
                     let mut span = self.current.span.clone();
                     span.start_index += 1;
@@ -416,16 +411,15 @@ impl<'t, 'contents> Parser<'t, 'contents> {
                     ReportKind::SyntaxError
                         .new("Register number contains an invalid digit")
                         .with_label(ReportLabel::new(self.current.span.clone()))
-                        .with_note(
-                            "HINT: Registers follow the format r<ident>. e.g r8 r32",
-                        )
+                        .with_note("HINT: Registers follow the format r<ident>. e.g r8 r32")
                 },
                 _ => ReportKind::SyntaxError
                     .new("Register identifier intager overflows")
                     .with_label(ReportLabel::new(self.current.span.clone()))
                     .with_note("HINT: You dont have this many registers. Trust me"),
-            }.into(),
-            Ok(i) => Ok(Type::Register { inner: inner.map(|t| Box::new(t)), ident: i })
+            }
+            .into(),
+            Ok(i) => Ok(Type::Register { inner: inner.map(|t| Box::new(t)), ident: i }),
         }
     }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -37,6 +37,7 @@ pub enum ReportKind {
     UnexpectedEOF,
     InvalidEscapeSequence,
     DuplicateAttribute,
+    RegisterWithinHeap,
 
     // General
     IOError,
@@ -70,6 +71,7 @@ impl ReportKind {
             | Self::UnexpectedEOF
             | Self::DuplicateAttribute
             | Self::InvalidEscapeSequence
+            | Self::RegisterWithinHeap
 
             // General
             | Self::IOError | Self::SyntaxError => Level::Error,


### PR DESCRIPTION
Test cases:
```shard
%1
%4
%9272
%[1]
%[]
%[3, 8, 99, 3:7]
%{7:}
%{9, [2:]}
%[{1}]
%{[{[]}]}
%Hello
%9999999999999
%cRazY
%;r2929
%{4, 2};r2
%8;r82
%Position;r2
%[1:];r7


%902385u9035y97w
%_289748
%0000000
%[1:0]
%[999999999:000000000000000000000000000000]
%{lfj}
%0
%{,,,,,,,,}
%[,,,,,,,,]
%{20, 2 ]
%{20::::}
%[::::]
%{:4}
%{8;r8:42}
%{}
%[;r29]
%383;kf-
%r
%;r980054230994204937850476047603760703476340763706347089175720520257450
%{8
%[{[{{[]}]}]
%;r
%[2 3:5]
%{{[{]]]]][}
%[]][]}[[[}[]]]{{{{]}}}}[{{][]]}}[}}
%r22313132
%[;r2
%r9283w938
%{8:kssll}
%{8:r2}
%9148130572475669346783467809767067067506370670356730576
```